### PR TITLE
🎁 Add SimpleSchemaLoaderDecorator for work types

### DIFF
--- a/app/services/hyrax/simple_schema_loader_decorator.rb
+++ b/app/services/hyrax/simple_schema_loader_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v5.0.0 to add schemas that are located in config/metadata/*.yaml
+
+module Hyrax
+  module SimpleSchemaLoaderDecorator
+    def config_search_paths
+      super + [HykuKnapsack::Engine.root]
+    end
+  end
+end
+
+Hyrax::SimpleSchemaLoader.prepend(Hyrax::SimpleSchemaLoaderDecorator)


### PR DESCRIPTION
# Story

This decorator needs to be in play for the work types to load their respective yaml files.  This is necessary for Valkyrie resources.
