### PR TITLE
♻️ Run bundle when migrations present

### DIFF
--- a/db-migrate-seed.sh
+++ b/db-migrate-seed.sh
@@ -10,6 +10,7 @@ db-wait.sh "$SOLR_HOST:$SOLR_PORT"
 migrations_run=`PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER $DB_NAME -t -c "SELECT version FROM schema_migrations ORDER BY schema_migrations" | wc -c`
 migrations_fs=`ls -l db/migrate/ | awk '{print $9}' | grep -o '[0-9]\+' | wc -c`
 if [[ "$migrations_run" -lt "$migrations_fs" ]]; then
+    bundle
     bundle exec rails db:create
     bundle exec rails db:migrate
     bundle exec rails db:seed


### PR DESCRIPTION
Prior to this commit, we might have a situation where the initialize_app
container's gems are not what is indicated by the Gemfile.lock.  Which
creates problems when we run the `bundle exec rails db:create`; namely
the error will mention that we don't have the gem installed.

We can circumvent this via different docker compose files; however, it
seems reasonable to demand that we `bundle` before we execute `bundle
exec`; especially when we consider the fact that we're not always
running migrations.