### PR TITLE
DRAFT: Improve DX: setup script for submodule and image syncing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/samvera/hyku/base:latest as hyku-knap-base
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS hyku-knap-base
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera

--- a/README.md
+++ b/README.md
@@ -99,7 +99,29 @@ git switch -c required_for_knapsack_instances
 
 For Hyku to build with Knapsack, we need a local branch named `required_for_knapsack_instances`.  _Note:_ As we work more with Knapsack maintenance there may be improvements to this shim.
 
-#### Hyku Submodule
+#### Automated Setup Script
+We now provide an automated setup script that handles the Hyku submodule initialization and Docker environment configuration. This script performs the following tasks:
+- Initializes and updates the hyrax-webapp submodule
+- Verifies that Docker is running
+- Sets the proper BASE_IMAGE in your .env file based on the submodule SHA
+- Installs a git hook to automatically update your environment when the submodule changes
+
+To use the setup script, run:
+```bash
+./bin/setup
+```
+
+After running the setup script, you can build and run your Docker containers:
+
+```bash
+docker compose build
+docker compose up
+```
+
+The git hook ensures that whenever you update the Hyku submodule, your Docker environment will automatically be configured to use the correct base image matching your submodule version.
+
+#### Manual Hyku Submodule Setup (Alternative)
+If you prefer to manually manage the Hyku submodule, you can follow these steps instead of using the automated setup script:
 
 A newly cloned knapsack will have an empty `./hyrax-webapp` directory.  That is where the Hyku application will exist.  The version of Hyku is managed via a [Git submodule](https://git-scm.com/docs/git-submodule).
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -e
+
+echo "🚀 Starting project setup..."
+
+# 🐙 Step 1: Init submodule if it hasn't been cloned yet
+if [ ! -f "hyrax-webapp/.git" ]; then
+  echo "📦 Initializing hyrax-webapp submodule..."
+  git submodule update --init --recursive
+else
+  echo "📦 hyrax-webapp already checked out — skipping submodule update"
+fi
+
+# 🐳 Step 2: Make sure Docker is running
+if ! docker info >/dev/null 2>&1; then
+  echo "❌ Docker is not running. Please start Docker Desktop or your Docker daemon."
+  exit 1
+fi
+
+# 🧠 Step 3: Set BASE_IMAGE from the submodule SHA
+echo "🔧 Setting BASE_IMAGE in .env..."
+SUBMODULE_SHA=$(cd hyrax-webapp && git rev-parse --short=8 HEAD)
+BASE_IMAGE="ghcr.io/samvera/hyku/base:$SUBMODULE_SHA"
+
+# Create or update .env file
+if grep -q '^BASE_IMAGE=' .env 2>/dev/null; then
+  sed -i.bak "s|^BASE_IMAGE=.*|BASE_IMAGE=$BASE_IMAGE|" .env && rm .env.bak
+else
+  echo "BASE_IMAGE=$BASE_IMAGE" >> .env
+fi
+echo "✅ BASE_IMAGE set to $BASE_IMAGE"
+
+# 🪝 Step 4: Install a post-checkout git hook to auto-update .env if submodule changes
+HOOK_PATH=".git/hooks/post-checkout"
+if [ ! -f "$HOOK_PATH" ]; then
+  echo "🪝 Installing post-checkout git hook..."
+  cat > "$HOOK_PATH" <<EOF
+#!/usr/bin/env bash
+if git diff --name-only HEAD@{1} HEAD | grep -q "^hyrax-webapp"; then
+  echo "🌀 hyrax-webapp submodule changed — re-running setup to update BASE_IMAGE..."
+  ./bin/setup
+fi
+EOF
+  chmod +x "$HOOK_PATH"
+  echo "✅ post-checkout hook installed"
+else
+  echo "ℹ️ Git hook already installed at $HOOK_PATH"
+fi
+
+echo "🎉 Setup complete! You can now run:"
+echo ""
+echo "  docker compose build"
+echo "  docker compose up"
+echo ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ x-app: &app
     args:
       BUILDKIT_INLINE_CACHE: 1
       APP_PATH: ./hyrax-webapp
+      BASE_IMAGE: ${BASE_IMAGE}
   image: ghcr.io/samvera-labs/hyku_knapsack:${TAG:-latest}
   environment:
     # This line is what makes the knapsack include use the local code instead of the remote gem
@@ -62,7 +63,7 @@ services:
     extends:
       file: hyrax-webapp/docker-compose.yml
       service: base
-    image: ghcr.io/samvera/hyku/base:${TAG:-latest}
+    image: ${BASE_IMAGE}
     command: bash -l -c "echo 'base is only used for building base images, which in turn reduces image build times. It does not need to be run'"
 
   web:
@@ -93,6 +94,7 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
         APP_PATH: ./hyrax-webapp
+        BASE_IMAGE: ${BASE_IMAGE}
     image: ghcr.io/samvera-labs/hyku_knapsack/worker:${TAG:-latest}
     # Uncomment command to access container with out starting bin/worker. Useful for debugging or updating Gemfile.lock
     # command: sleep infinity


### PR DESCRIPTION
TO-DO
- [ ] Update the build to use the base_image as well


Update to add `bin/setup` for submodule initialization and BASE_IMAGE automation

# Story

As a developer working on a HykuKnapsack project,  
I want a single setup script that initializes the Hyku submodule and automatically sets the correct `BASE_IMAGE`,  
So that I can start coding immediately without having to manually manage submodule state or rebuild Docker layers unnecessarily.

Refs #<issue_number>

# Expected Behavior Before Changes

- Developers had to manually run multiple setup steps when starting work:
  - Initialize the `hyrax-webapp` submodule
  - Manually determine the correct SHA and update `.env` with the appropriate `BASE_IMAGE`
- If the submodule SHA changed (e.g., via `git checkout`), the `.env` file would not be updated automatically
- Builds could use outdated base images or default to `:latest`, which could lead to unnecessary rebuilds and slower startup times

# Expected Behavior After Changes

- Running `./bin/setup` will:
  - Automatically initialize the `hyrax-webapp` submodule (if not already)
  - Set the `BASE_IMAGE` in `.env` to match the currently checked-out commit in the submodule
  - Install a `post-checkout` git hook to keep `BASE_IMAGE` updated when switching branches
- Ensures the correct base image is used:
  - Matches the SHA of the `hyrax-webapp` submodule
  - Leverages Docker layer caching more effectively
  - Speeds up local development and reduces build inconsistencies
