### PR TITLE
Rake task to generate missing knapsack translations

### DIFF
--- a/lib/tasks/hyku_knapsack_tasks.rake
+++ b/lib/tasks/hyku_knapsack_tasks.rake
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
-# desc "Explaining what the task does"
-# task :hyku_knapsack do
-#   # Task goes here
-# end
+
+namespace :hyku_knapsack do
+  namespace :i18n do
+    desc 'Translate missing locale keys from English to all other languages'
+    task translate_missing: :environment do
+      hyku_i18n_config_path = '/app/samvera/hyrax-webapp/config/i18n-tasks.yml'
+
+      sh "cd /app/samvera && bundle exec i18n-tasks translate-missing --config #{hyku_i18n_config_path} --from en de es fr it pt-BR zh"
+    end
+  end
+end


### PR DESCRIPTION
If the `i18n-tasks translate-missing` task is run in a knapsack app directly like it would be in Hyku, the results are not the same for two reasons:
1. The knapsack locales are in `/app/samvera` as opposed to `/app/samvera/hyrax-webapp`
2. Hyku has an i18n config file and hyku_knapsack does not 

This task allows a dev to get the same result that they would expect running `i18n-tasks translate-missing` directly in Hyku.