### PR TITLE
:bug: Fix bundler inject

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM ghcr.io/samvera/hyku/base:latest as hyku-knap-base
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera
-COPY --chown=1001:101 bundler.d/ /app/.bundler.d/
+RUN ln -s /app/samvera/bundler.d /app/.bundler.d
 ENV BUNDLE_LOCAL__HYKU_KNAPSACK=/app/samvera
 ENV BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
-ENV BUNDLE_BUNDLER_INJECT__GEM_PATH=/app/samvera/bundler.d
 
 RUN bundle install --jobs "$(nproc)"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ x-app: &app
     # This line is what makes the knapsack include use the local code instead of the remote gem
     - BUNDLE_LOCAL__HYKU_KNAPSACK=/app/samvera
     - BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
-    - BUNDLE_BUNDLER_INJECT__GEM_PATH=/app/samvera/bundler.d
   volumes:
     - node_modules:/app/samvera/hyrax-webapp/node_modules:cached
     - uploads:/app/samvera/hyrax-webapp/public/uploads:cached

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -69,8 +69,6 @@ extraEnvVars: &envVars
     value: /app/samvera
   - name: BUNDLE_DISABLE_LOCAL_BRANCH_CHECK
     value: "true"
-  - name: BUNDLE_BUNDLER_INJECT__GEM_PATH
-    value: /app/samvera/bundler.d
   - name: CONFDIR
     value: "/app/samvera/hyrax-webapp/solr/conf"
   - name: CLIENT_ADMIN_USER_EMAIL


### PR DESCRIPTION
fix ported over from ref:
- https://github.com/notch8/palni_palci_knapsack/pull/120/files

This will allow us to pin override gem versions in bundler.d/example.rb.

