### PR TITLE
remove hyku_specs symlink

### DIFF
--- a/spec/hyku_specs
+++ b/spec/hyku_specs
@@ -1,1 +1,0 @@
-../hyrax-webapp/spec

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,6 @@
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
-require File.expand_path("hyku_specs/rails_helper.rb", __dir__)
 
 ENV["RAILS_ENV"] ||= "test"
 # require File.expand_path('../config/environment', __dir__)
@@ -43,10 +42,4 @@ RSpec.configure do |config|
   config.include HykuKnapsack::Engine.routes.url_helpers
   config.include Capybara::DSL
   config.include Fixtures::FixtureFileUpload
-
-  # To run specs locally without the spec/hyku_specs/ directory do: `bundle exec rspec --tag ~hyku`
-  config.define_derived_metadata(file_path: %r{spec/hyku_specs/}) do |metadata|
-    metadata[:hyku] = true
-  end
-  ## End override
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,4 @@
 # frozen_string_literal: true
 
-RSpec.configure do |config|
-  # Look for an overriding spec file and skip if it exists
-  config.around do |example|
-    if example.file_path.starts_with?("./spec/hyku_specs") && File.exist?(example.file_path.sub("./spec/hyku_specs", "."))
-      skip "Override exists of this test file in engine."
-    else
-      example.run
-    end
-  end
-end
-
-require File.expand_path("hyku_specs/rails_helper.rb", __dir__)
-require File.expand_path("hyku_specs/spec_helper.rb", __dir__)
+require File.expand_path("../hyrax-webapp/spec/rails_helper.rb", __dir__)
+require File.expand_path("../hyrax-webapp/spec/spec_helper.rb", __dir__)


### PR DESCRIPTION
Knapsack should run its specs only, and not be concerned about hyku's specs.

