### PR TITLE
:bug: Swap logic for config_search_paths

### DIFF
--- a/app/services/hyrax/simple_schema_loader_decorator.rb
+++ b/app/services/hyrax/simple_schema_loader_decorator.rb
@@ -5,7 +5,7 @@
 module Hyrax
   module SimpleSchemaLoaderDecorator
     def config_search_paths
-      super + [HykuKnapsack::Engine.root]
+      [HykuKnapsack::Engine.root] + super
     end
   end
 end


### PR DESCRIPTION
Randy K. spotted a bug - hyku knapsack was not overriding hyku files when HYRAX_FLEXIBLE=false

He confirmed that swapping this logic works.

