### PR TITLE
Improve spec_helper and rails_helper for Hyku 7 and shared specs

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -7,7 +7,9 @@ Rails.application.config.after_initialize do
     config.flexible = ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYRAX_FLEXIBLE', 'false'))
 
     # Prepend to ensure knapsack profile is checked before the host app's profiles.
-    config.schema_loader_config_search_paths.unshift(HykuKnapsack::Engine.root) \
-      if config.respond_to?(:schema_loader_config_search_paths)
+    if config.respond_to?(:schema_loader_config_search_paths)
+      paths = config.schema_loader_config_search_paths
+      config.schema_loader_config_search_paths = [HykuKnapsack::Engine.root] + Array(paths)
+    end
   end
 end

--- a/lib/hyku_knapsack/engine.rb
+++ b/lib/hyku_knapsack/engine.rb
@@ -45,8 +45,8 @@ module HykuKnapsack
       # end
 
       # Add knapsack schema search path
-      if config.respond_to?(:schema_loader_config_search_paths)
-        config.schema_loader_config_search_paths += [HykuKnapsack::Engine.root]
+      if Hyrax.config.respond_to?(:schema_loader_config_search_paths)
+        Hyrax.config.schema_loader_config_search_paths += [HykuKnapsack::Engine.root]
       else
         # Ensure we are prepending the Hyku::SimpleSchemaLoaderDecorator early
         require HykuKnapsack::Engine.root.join('app', 'services', 'hyrax', 'simple_schema_loader_decorator')

--- a/lib/hyku_knapsack/engine.rb
+++ b/lib/hyku_knapsack/engine.rb
@@ -65,11 +65,8 @@ module HykuKnapsack
 
       # Prepend knapsack root so its config/metadata/*.yaml schemas are found first.
       if Hyrax.config.respond_to?(:schema_loader_config_search_paths)
-        Hyrax.config.schema_loader_config_search_paths.unshift(HykuKnapsack::Engine.root)
-      else
-        # Ensure we are prepending the Hyku::SimpleSchemaLoaderDecorator early
-        require HykuKnapsack::Engine.root.join('app', 'services', 'hyrax', 'simple_schema_loader_decorator')
-        Hyrax::SimpleSchemaLoader.prepend(Hyrax::SimpleSchemaLoaderDecorator)
+        paths = Hyrax.config.schema_loader_config_search_paths
+        Hyrax.config.schema_loader_config_search_paths = [HykuKnapsack::Engine.root] + Array(paths)
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,46 +5,66 @@
 ENV["RAILS_ENV"] ||= "test"
 # Use Hyku default (false) unless a spec or .env sets HYRAX_FLEXIBLE.
 ENV['HYRAX_FLEXIBLE'] ||= 'false'
+# Mirror the env setup from hyrax-webapp/spec/rails_helper.rb so Rails initializers
+# (especially analytics and routing) behave correctly in test mode.
+ENV['HYKU_ADMIN_HOST'] = 'test.host'
+ENV['HYKU_ROOT_HOST'] = 'test.host'
+ENV['HYKU_ADMIN_ONLY_TENANT_CREATION'] = nil
+ENV['HYKU_DEFAULT_HOST'] = nil
+ENV['HYKU_MULTITENANT'] = 'true'
+ENV['VALKYRIE_TRANSITION'] = 'true'
+ENV['HYRAX_ANALYTICS_REPORTING'] = 'false'
+
+# Boot Rails FIRST, before loading spec_helper.
+# This ensures ENV is correctly set when Rails initializers run,
+# and makes Rails.root available for spec_helper (which may load hyrax_with_valkyrie_helper).
+require File.expand_path("../hyrax-webapp/config/environment", __dir__)
+abort("The Rails environment is running in production mode!") if Rails.env.production?
 
 require "spec_helper"
-
-# require File.expand_path('../config/environment', __dir__)
-require File.expand_path("../hyrax-webapp/config/environment", __dir__)
-# Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
-# Add additional requires below this line. Rails is not loaded until this point!
 require "factory_bot_rails"
-FactoryBot.definition_file_paths = [File.expand_path("spec/factories", HykuKnapsack::Engine.root)]
-FactoryBot.find_definitions
-
 require 'capybara/rails'
 require 'dry-validation'
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-# Require supporting ruby files from spec/support/ and subdirectories.  Note: engine, not Rails.root context.
+require 'database_cleaner'
+
+# Configure Hyrax to use Valkyrie-based models in tests (matches hyrax-webapp rails_helper).
+Hyrax.config.admin_set_model = "AdminSetResource"
+Hyrax.config.collection_model = "CollectionResource"
+
+# Load factories from Hyrax's shared specs, hyrax-webapp, and this engine.
+# This allows specs to use Hyrax shared examples (e.g. "a Hyrax::Work") and webapp factories.
+FactoryBot.definition_file_paths = [
+  Hyrax::Engine.root.join("lib/hyrax/specs/shared_specs/factories").to_s,
+  File.expand_path("spec/factories", Rails.root),
+  File.expand_path("spec/factories", HykuKnapsack::Engine.root)
+]
+FactoryBot.find_definitions
+
+# Load only knapsack-specific support files (not all of hyrax-webapp's).
 Dir[HykuKnapsack::Engine.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
-RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec', 'fixtures')
+ActiveRecord::Migration.maintain_test_schema!
 
-  # They enable url_helpers not to throw error in Rspec system spec and request spec.
-  # config.include Rails.application.routes.url_helpers
-  # TODO is this needed?
+RSpec.configure do |config|
+  config.fixture_paths = [Rails.root.join('spec', 'fixtures')]
+  config.use_transactional_fixtures = false
+
   config.include HykuKnapsack::Engine.routes.url_helpers
   config.include Capybara::DSL
-  # Only include Fixtures::FixtureFileUpload if it's defined (from hyrax-webapp)
   config.include Fixtures::FixtureFileUpload if defined?(Fixtures::FixtureFileUpload)
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include FactoryBot::Syntax::Methods
+  config.include ApplicationHelper, type: :view
+  config.include Warden::Test::Helpers, type: :feature
+  config.include ActiveJob::TestHelper
+
+  config.before do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.start
+  end
+
+  config.after do
+    DatabaseCleaner.clean
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,7 +63,12 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.start
   end
-
+# Appeasing the Hyrax user factory interface.
+def RoleMapper.add(user:, groups:)
+  groups.each do |group|
+    user.add_role(group.to_sym, Site.instance)
+  end
+end
   config.after do
     DatabaseCleaner.clean
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../hyrax-webapp/spec/rails_helper.rb", __dir__)
+# Load hyrax-webapp's spec_helper for WebMock, rspec-its, Valkyrie adapter registration,
+# and shared RSpec configuration. Rails must already be booted before this is required
+# (see rails_helper.rb which boots Rails first, then requires spec_helper).
 require File.expand_path("../hyrax-webapp/spec/spec_helper.rb", __dir__)


### PR DESCRIPTION
- Boot Rails from knapsack rails_helper (after ENV) then require only webapp spec_helper
- Set ENV to mirror hyrax-webapp test env; keep HYRAX_FLEXIBLE default false
- Use config.fixture_paths (plural); add Hyrax + webapp factory paths
- Set Hyrax Valkyrie test config; add DatabaseCleaner, Devise, Warden, ActiveJob includes

These changes were needed in downstream projects (pals, hyku up)


# Summary

This PR updates the knapsack test setup so Rails boots once with ENV set before initializers, and so specs can use Hyrax shared examples and webapp factories. Summary of changes:

- **Boot order:** The knapsack boots Rails from its own `rails_helper` (after setting ENV), then requires only the webapp `spec_helper`. The webapp `rails_helper` is no longer required, so Rails is not loaded twice and ENV is in place before any initializers run.
- **ENV:** Test env is aligned with hyrax-webapp (`HYKU_ADMIN_HOST`, `HYKU_ROOT_HOST`, `VALKYRIE_TRANSITION`, `HYRAX_ANALYTICS_REPORTING`, etc.). `HYRAX_FLEXIBLE` keeps the Hyku default via `ENV['HYRAX_FLEXIBLE'] ||= 'false'`.
- **fixture_paths:** Uses `config.fixture_paths` (plural), the current RSpec/Rails API, instead of the deprecated `config.fixture_path`.
- **Factory paths:** Adds Hyrax shared spec factories and hyrax-webapp factories so specs can use shared examples (e.g. "a Hyrax::Work") and webapp factories.
- **Valkyrie test config:** Sets `Hyrax.config.admin_set_model` and `Hyrax.config.collection_model` in test to match hyrax-webapp.
- **DatabaseCleaner, Devise, Warden, ApplicationHelper, ActiveJob:** Adds DatabaseCleaner and the usual includes so controller, view, and feature specs work when knapsacks add those spec types.


# Screenshots / Video

N/A (test configuration only).

# Expected Behavior

- Specs run with Rails booted once and ENV set before initializers.
- Specs that use Hyrax shared examples or webapp factories can load them.
- Controller, view, and feature specs have the same helpers as the webapp when those spec types are used.
- Default flexible metadata behavior is unchanged; `HYRAX_FLEXIBLE` stays `false` unless a spec or .env sets it.

# Notes

- Existing knapsack specs should keep working. `spec_helper` now pulls in only the webapp `spec_helper` (WebMock, rspec-its, Valkyrie adapter, etc.), not the webapp `rails_helper`.