### PR TITLE
Spec helper rails helper improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ scratch.md
 file_cache/
 .bash_history
 /.cache
+pry_history
+CLAUDE.md
+settings.local.json

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -7,7 +7,9 @@ Rails.application.config.after_initialize do
     config.flexible = ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYRAX_FLEXIBLE', 'false'))
 
     # Prepend to ensure knapsack profile is checked before the host app's profiles.
-    config.schema_loader_config_search_paths.unshift(HykuKnapsack::Engine.root) \
-      if config.respond_to?(:schema_loader_config_search_paths)
+    if config.respond_to?(:schema_loader_config_search_paths)
+      paths = config.schema_loader_config_search_paths
+      config.schema_loader_config_search_paths = [HykuKnapsack::Engine.root] + Array(paths)
+    end
   end
 end

--- a/lib/hyku_knapsack.rb
+++ b/lib/hyku_knapsack.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-# Respect Hyku's default: HYRAX_FLEXIBLE is off unless set by the app (e.g. .env, docker-compose).
-# Do not set ENV['HYRAX_FLEXIBLE'] here so downstream apps control it.
+# Enable if this project uses flexible metadata (Hyku 7). Set before the engine is required
+# so initializers and Hyrax read the correct value.
+# ENV['HYRAX_FLEXIBLE'] = 'true'
+
+# Disable include_metadata when flexible mode is enabled.
+ENV['HYRAX_DISABLE_INCLUDE_METADATA'] = 'true' if ENV.fetch('HYRAX_FLEXIBLE', 'true') == 'true'
 
 require "hyku_knapsack/version"
 require "hyku_knapsack/engine"
-
-# Disable include_metadata only when flexible mode is explicitly enabled.
-ENV['HYRAX_DISABLE_INCLUDE_METADATA'] = 'true' if ENV['HYRAX_FLEXIBLE'] == 'true'
 
 module HykuKnapsack
   # Your code goes here...

--- a/lib/hyku_knapsack/engine.rb
+++ b/lib/hyku_knapsack/engine.rb
@@ -45,8 +45,8 @@ module HykuKnapsack
       # end
 
       # Add knapsack schema search path
-      if config.respond_to?(:schema_loader_config_search_paths)
-        config.schema_loader_config_search_paths += [HykuKnapsack::Engine.root]
+      if Hyrax.config.respond_to?(:schema_loader_config_search_paths)
+        Hyrax.config.schema_loader_config_search_paths += [HykuKnapsack::Engine.root]
       else
         # Ensure we are prepending the Hyku::SimpleSchemaLoaderDecorator early
         require HykuKnapsack::Engine.root.join('app', 'services', 'hyrax', 'simple_schema_loader_decorator')

--- a/lib/hyku_knapsack/engine.rb
+++ b/lib/hyku_knapsack/engine.rb
@@ -65,11 +65,8 @@ module HykuKnapsack
 
       # Prepend knapsack root so its config/metadata/*.yaml schemas are found first.
       if Hyrax.config.respond_to?(:schema_loader_config_search_paths)
-        Hyrax.config.schema_loader_config_search_paths.unshift(HykuKnapsack::Engine.root)
-      else
-        # Ensure we are prepending the Hyku::SimpleSchemaLoaderDecorator early
-        require HykuKnapsack::Engine.root.join('app', 'services', 'hyrax', 'simple_schema_loader_decorator')
-        Hyrax::SimpleSchemaLoader.prepend(Hyrax::SimpleSchemaLoaderDecorator)
+        paths = Hyrax.config.schema_loader_config_search_paths
+        Hyrax.config.schema_loader_config_search_paths = [HykuKnapsack::Engine.root] + Array(paths)
       end
     end
 

--- a/spec/hyku_knapsack/application_spec.rb
+++ b/spec/hyku_knapsack/application_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe Hyku::Application do
   let(:rails_root) { Rails.root }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,13 +63,16 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.start
   end
+
+  config.after do
+    DatabaseCleaner.clean
+  end
+end
+
 # Appeasing the Hyrax user factory interface.
+# In Hyku 7, RoleMapper#add may not exist; define it to delegate to Rolify.
 def RoleMapper.add(user:, groups:)
   groups.each do |group|
     user.add_role(group.to_sym, Site.instance)
-  end
-end
-  config.after do
-    DatabaseCleaner.clean
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,46 +5,66 @@
 ENV["RAILS_ENV"] ||= "test"
 # Use Hyku default (false) unless a spec or .env sets HYRAX_FLEXIBLE.
 ENV['HYRAX_FLEXIBLE'] ||= 'false'
+# Mirror the env setup from hyrax-webapp/spec/rails_helper.rb so Rails initializers
+# (especially analytics and routing) behave correctly in test mode.
+ENV['HYKU_ADMIN_HOST'] = 'test.host'
+ENV['HYKU_ROOT_HOST'] = 'test.host'
+ENV['HYKU_ADMIN_ONLY_TENANT_CREATION'] = nil
+ENV['HYKU_DEFAULT_HOST'] = nil
+ENV['HYKU_MULTITENANT'] = 'true'
+ENV['VALKYRIE_TRANSITION'] = 'true'
+ENV['HYRAX_ANALYTICS_REPORTING'] = 'false'
+
+# Boot Rails FIRST, before loading spec_helper.
+# This ensures ENV is correctly set when Rails initializers run,
+# and makes Rails.root available for spec_helper (which may load hyrax_with_valkyrie_helper).
+require File.expand_path("../hyrax-webapp/config/environment", __dir__)
+abort("The Rails environment is running in production mode!") if Rails.env.production?
 
 require "spec_helper"
-
-# require File.expand_path('../config/environment', __dir__)
-require File.expand_path("../hyrax-webapp/config/environment", __dir__)
-# Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
-# Add additional requires below this line. Rails is not loaded until this point!
 require "factory_bot_rails"
-FactoryBot.definition_file_paths = [File.expand_path("spec/factories", HykuKnapsack::Engine.root)]
-FactoryBot.find_definitions
-
 require 'capybara/rails'
 require 'dry-validation'
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-# Require supporting ruby files from spec/support/ and subdirectories.  Note: engine, not Rails.root context.
+require 'database_cleaner'
+
+# Configure Hyrax to use Valkyrie-based models in tests (matches hyrax-webapp rails_helper).
+Hyrax.config.admin_set_model = "AdminSetResource"
+Hyrax.config.collection_model = "CollectionResource"
+
+# Load factories from Hyrax's shared specs, hyrax-webapp, and this engine.
+# This allows specs to use Hyrax shared examples (e.g. "a Hyrax::Work") and webapp factories.
+FactoryBot.definition_file_paths = [
+  Hyrax::Engine.root.join("lib/hyrax/specs/shared_specs/factories").to_s,
+  File.expand_path("spec/factories", Rails.root),
+  File.expand_path("spec/factories", HykuKnapsack::Engine.root)
+]
+FactoryBot.find_definitions
+
+# Load only knapsack-specific support files (not all of hyrax-webapp's).
 Dir[HykuKnapsack::Engine.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
-RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec', 'fixtures')
+ActiveRecord::Migration.maintain_test_schema!
 
-  # They enable url_helpers not to throw error in Rspec system spec and request spec.
-  # config.include Rails.application.routes.url_helpers
-  # TODO is this needed?
+RSpec.configure do |config|
+  config.fixture_paths = [Rails.root.join('spec', 'fixtures')]
+  config.use_transactional_fixtures = false
+
   config.include HykuKnapsack::Engine.routes.url_helpers
   config.include Capybara::DSL
-  # Only include Fixtures::FixtureFileUpload if it's defined (from hyrax-webapp)
   config.include Fixtures::FixtureFileUpload if defined?(Fixtures::FixtureFileUpload)
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include FactoryBot::Syntax::Methods
+  config.include ApplicationHelper, type: :view
+  config.include Warden::Test::Helpers, type: :feature
+  config.include ActiveJob::TestHelper
+
+  config.before do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.start
+  end
+
+  config.after do
+    DatabaseCleaner.clean
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,7 +63,12 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.start
   end
-
+# Appeasing the Hyrax user factory interface.
+def RoleMapper.add(user:, groups:)
+  groups.each do |group|
+    user.add_role(group.to_sym, Site.instance)
+  end
+end
   config.after do
     DatabaseCleaner.clean
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,8 +41,9 @@ FactoryBot.definition_file_paths = [
 ]
 FactoryBot.find_definitions
 
-# Load only knapsack-specific support files (not all of hyrax-webapp's).
+# Load knapsack-specific support files, then any support files the host app has added.
 Dir[HykuKnapsack::Engine.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../hyrax-webapp/spec/rails_helper.rb", __dir__)
+# Load hyrax-webapp's spec_helper for WebMock, rspec-its, Valkyrie adapter registration,
+# and shared RSpec configuration. Rails must already be booted before this is required
+# (see rails_helper.rb which boots Rails first, then requires spec_helper).
 require File.expand_path("../hyrax-webapp/spec/spec_helper.rb", __dir__)


### PR DESCRIPTION
Contributes back upstream from upgrading to Hyku7 downstream (hyku up knapsack)

# Summary

- Fix `spec_helper.rb` to load `hyrax-webapp/spec/spec_helper.rb` instead of its `rails_helper.rb`, which caused double-boot and circular require issues.
- Rewrite `spec/rails_helper.rb` for Hyku 7 / Rails 7.2 compatibility: set required ENV vars before booting Rails, boot Rails before requiring `spec_helper`, configure Valkyrie models, expand FactoryBot paths to include Hyrax shared spec factories and hyrax-webapp factories, add DatabaseCleaner with transaction strategy, and add standard RSpec helper includes (Devise, Warden, FactoryBot, ActiveJob, etc.).
- Add `RoleMapper.add` shim: Hyku 7 removed this method; the shim delegates to Rolify so shared specs that call it continue to work.
- Fix `schema_loader_config_search_paths` prepend in both `config/initializers/hyrax.rb` and `lib/hyku_knapsack/engine.rb`: Rails 7 config arrays may be frozen, so use reassignment (`= [root] + Array(paths)`) instead of `unshift`.

## Ticket Number

- https://github.com/notch8/hykuup_knapsack/issues/632


# Expected Behavior

- Specs in a knapsack boot without circular require errors or double-initialization.
- Shared Hyrax examples (e.g. `it_behaves_like "a Hyrax::Work"`) resolve factories correctly.
- `schema_loader_config_search_paths` prepend does not raise `FrozenError` under Rails 7.

