### PR TITLE
Fix duplicated includes from the work_resource generator

### DIFF
--- a/lib/generators/hyku_knapsack/work_resource/work_resource_generator.rb
+++ b/lib/generators/hyku_knapsack/work_resource/work_resource_generator.rb
@@ -125,10 +125,19 @@ class HykuKnapsack::WorkResourceGenerator < Rails::Generators::NamedBase
   def insert_hyku_extra_includes_into_model
     model = File.join('../app/models/', class_path, "#{file_name}.rb")
     af_model = class_name.to_s.gsub('Resource', '')&.safe_constantize if class_name.end_with?('Resource')
-    insert_into_file model, before: "end" do
+    # Anchor on the class's closing `end` (column 0). A bare "end" anchor
+    # matches every `end` in the file, so the block was also being inserted
+    # inside the `if Hyrax.config.work_include_metadata?` guard emitted by the
+    # Hyrax work template, duplicating every include. The optional-feature
+    # schemas stay behind the same guard the stock Hyku models use so they do
+    # not load statically when flexible metadata is enabled.
+    insert_into_file model, before: /^end\s*\Z/ do
       <<-RUBY.gsub(/^ {8}/, '  ')
-        include Hyrax::Schema(:with_pdf_viewer)
-        include Hyrax::Schema(:with_video_embed)
+        if Hyrax.config.work_include_metadata?
+          include Hyrax::Schema(:with_pdf_viewer)
+          include Hyrax::Schema(:with_video_embed)
+        end
+
         include Hyrax::ArResource
         include Hyrax::NestedWorks
         #{"\n  Hyrax::ValkyrieLazyMigration.migrating(self, from: #{af_model})\n" if af_model}

--- a/lib/generators/hyku_knapsack/work_resource/work_resource_generator.rb
+++ b/lib/generators/hyku_knapsack/work_resource/work_resource_generator.rb
@@ -125,12 +125,7 @@ class HykuKnapsack::WorkResourceGenerator < Rails::Generators::NamedBase
   def insert_hyku_extra_includes_into_model
     model = File.join('../app/models/', class_path, "#{file_name}.rb")
     af_model = class_name.to_s.gsub('Resource', '')&.safe_constantize if class_name.end_with?('Resource')
-    # Anchor on the class's closing `end` (column 0). A bare "end" anchor
-    # matches every `end` in the file, so the block was also being inserted
-    # inside the `if Hyrax.config.work_include_metadata?` guard emitted by the
-    # Hyrax work template, duplicating every include. The optional-feature
-    # schemas stay behind the same guard the stock Hyku models use so they do
-    # not load statically when flexible metadata is enabled.
+    # Matches only the class's closing `end` at column 0, so the block is inserted once.
     insert_into_file model, before: /^end\s*\Z/ do
       <<-RUBY.gsub(/^ {8}/, '  ')
         if Hyrax.config.work_include_metadata?


### PR DESCRIPTION
### What does this PR do?

Fixes `HykuKnapsack::WorkResourceGenerator#insert_hyku_extra_includes_into_model`:

1. The insertion anchor `before: "end"` matches **every** `end` in the generated model (Thor's `insert_into_file` replaces all occurrences), so the Hyku extras block was inserted twice — once inside the `if Hyrax.config.work_include_metadata?` guard emitted by the current Hyrax work template, and once at the class close. Anchoring on the class-closing `end` at column 0 (`/^end\s*\Z/`) inserts exactly once.
2. The inserted `Hyrax::Schema(:with_pdf_viewer)` / `(:with_video_embed)` includes are now wrapped in the same `work_include_metadata?` guard the stock Hyku models (e.g. `GenericWorkResource`) use, so they no longer load static schemas when flexible metadata is enabled (`HYRAX_DISABLE_INCLUDE_METADATA=true`).

### Why?

Generated against current Hyku 7.1.x, `rails generate hyku_knapsack:work_resource Design` produces a model with every include duplicated and the schema includes applied unguarded — under flexible metadata that means static schema attributes are mixed into a class whose metadata is supposed to come entirely from the tenant M3 profile. Anyone following the README's custom-work-type instructions gets a model they must hand-clean before it behaves like the stock work types; for first-time knapsack adopters that's a confusing first experience with the tool that's supposed to make Hyku customization safe.

Reproduction (before this change), single generator run:

```ruby
class Throwaway < Hyrax::Work
  if Hyrax.config.work_include_metadata?
    include Hyrax::Schema(:core_metadata) unless Hyrax.config.work_default_metadata?
    include Hyrax::Schema(:basic_metadata)
    include Hyrax::Schema(:throwaway)
    include Hyrax::Schema(:with_pdf_viewer)   # <- extras inserted inside the guard
    ...
    prepend OrderAlready.for(:creator)
  end
  include Hyrax::Schema(:with_pdf_viewer)     # <- and again at class close, unguarded
  ...
  prepend OrderAlready.for(:creator)
end
```

After this change the generated model matches the shape of Hyku's own `GenericWorkResource`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)